### PR TITLE
fix broken getImgAncestry on node 0.12

### DIFF
--- a/lib/registry-client-v1.js
+++ b/lib/registry-client-v1.js
@@ -277,6 +277,7 @@ RegistryClient.prototype._getCookies = function _getCookies(url) {
     if (cookies.length) {
         return cookies.join('; ');
     }
+    return '';
 };
 
 


### PR DESCRIPTION
Node is now stricter about passing undefined values to setHeader, which is what happens here if there are no cookies. `getImgAncestry` flat out doesn't work in `0.12`.

This change returns an empty cookie header if there are no cookies.