### PR TITLE
Allow V2 bearer token authentication.

### DIFF
--- a/lib/registry-client-v2.js
+++ b/lib/registry-client-v2.js
@@ -637,7 +637,9 @@ function ping(opts, cb) {
     });
 
     var headers = {};
-    if (opts.username) {
+    if (opts.authInfo) {
+        headers.authorization = _authHeaderFromAuthInfo(opts.authInfo);
+    } else if (opts.username) {
         headers.authorization = _basicAuthHeader(opts.username,
             opts.password);
     }
@@ -941,7 +943,8 @@ RegistryClientV2.prototype.ping = function regPing(cb) {
     ping(common.objMerge({
         indexName: this.repo.index.name,
         username: this.username,
-        password: this.password
+        password: this.password,
+        authInfo: this._authInfo
     }, this._commonHttpClientOpts), cb);
 };
 


### PR DESCRIPTION
V2 ping function doesn't provide a way for bearer token authentication.
With this commit, we pass the this._authInfo to ping function, and it is
valid, we use it.

Sample code:

```javascript
var docker = require('docker-registry-client');

var client = docker.createClientV2({name: 'taskcluster'});

client.ping(function(err, body, res) {
  if (err.statusCode == 401) {
    docker.loginV2({
      pingErr: err,
      pingRes: res,
      indexName: client.repo.index.name
    }, function(err, result) {
      client._authInfo = result.authInfo;

      client.ping(function(err, body, res) {
        if (!err) {
          console.log('Success!');
        } else {
          console.log('Fail...');
        }
      });
    });
  }
});
```