### PR TITLE
Update restify to get dtrace-provider@0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "bunyan": "1.x >=1.3.3",
         "jws": "3.1.0",
         "jwk-to-pem": "1.2.0",
-        "restify": "git+https://github.com/joyent/node-restify.git#066dd84",
+        "restify": "4.x",
         "strsplit": "1.x",
         "tough-cookie": "2.0.x",
         "vasync": "1.x >=1.6.1",


### PR DESCRIPTION
I've updated the restify package in order to deal with the dtrace-provider issue mentioned in #9
