### PR TITLE
joyent/node-docker-registry-client#23 Namespace validation too strict

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -33,7 +33,7 @@ var DEFAULT_LOGIN_SERVERNAME = 'https://index.docker.io/v1/';
 // 'DEFAULTTAG' from https://github.com/docker/docker/blob/0c7b51089c8cd7ef3510a9b40edaa139a7ca91aa/graph/tags.go#L25
 var DEFAULT_TAG = 'latest';
 
-var VALID_NS = /^[a-z0-9_-]*$/;
+var VALID_NS = /^[a-z0-9\._-]*$/;
 var VALID_REPO = /^[a-z0-9_\/\.-]*$/;
 
 
@@ -203,7 +203,7 @@ function parseRepo(arg, defaultIndex) {
         }
         if (! VALID_NS.test(ns)) {
             throw new Error('invalid repository namespace, may only contain ' +
-                '[a-z0-9_-] characters: ' + ns);
+                '[a-z0-9._-] characters: ' + ns);
         }
         if (ns[0] === '-' && ns[ns.length - 1] === '-') {
             throw new Error('invalid repository namespace, cannot start or ' +

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -363,6 +363,20 @@ test('parseRepo', function (t) {
         'canonicalName': 'myreg.example.com:1234/foo/bar'
     });
 
+    t.throws(function () { parseRepo('registry.gitlab.com/user@name/repo-a/repo-b'); },
+        /invalid repository namespace/);
+
+    t.deepEqual(parseRepo('registry.gitlab.com/user.name/repo-a/repo-b'), {
+        'index': {
+            'name': 'registry.gitlab.com',
+            'official': false
+        },
+        'official': false,
+        'remoteName': 'user.name/repo-a/repo-b',
+        'localName': 'registry.gitlab.com/user.name/repo-a/repo-b',
+        'canonicalName': 'registry.gitlab.com/user.name/repo-a/repo-b'
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Allow dot in namespace, to accommodate GitLab repos

Patch for #23. The new tests pass.